### PR TITLE
Extend Redmine library to support non GET method.

### DIFF
--- a/Redmine.cabal
+++ b/Redmine.cabal
@@ -1,5 +1,5 @@
 name: Redmine
-version: 0.0.3
+version: 0.0.5
 cabal-version: >=1.10
 build-type: Simple
 license: MIT
@@ -19,7 +19,7 @@ source-repository head
 Library
     default-language: Haskell2010
     build-depends: base >=2 && <5, old-locale -any,
-                   time -any, old-time -any, bytestring -any, http-conduit >= 2.1.0,
+                   time -any, old-time -any, bytestring -any, http-conduit >= 2.1.0, http-types, 
                    aeson -any, HTTP -any, network -any, text,
                    transformers, containers, http-client-tls,
                    resourcet, connection, MissingH

--- a/src/Redmine/Get.hs
+++ b/src/Redmine/Get.hs
@@ -14,155 +14,71 @@ module Redmine.Get ( getTimeEntries
                    , increaseQueryRange
                    ) where
 
-import Data.Aeson
-import Data.Maybe
 import Data.Monoid
 import qualified Data.Map as Map
-import Data.Tuple
+import Redmine.JSON
 import Redmine.Types
 import Redmine.Manager
-import Control.Applicative ((<$>), (<*>), pure)
+import Redmine.Rest
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
-import qualified Data.ByteString.Lazy as L
-import Network
-import Network.Connection (TLSSettings (..))
 import Network.HTTP.Conduit
+import Network.HTTP.Base (RequestMethod(..))
 import Network.HTTP.Client.TLS
-import Network.HTTP.Client.Conduit (defaultManagerSettings)
-import Data.Time.Format     (parseTime)
-import Data.Time.Clock      (UTCTime)
-import Data.Time.Calendar (Day)
-import System.Locale        (defaultTimeLocale)
-import Control.Monad        (liftM)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Maybe
-import Control.Monad.Trans.Resource
-import Data.String.Utils
 import Debug.Trace
-import qualified Data.Text as T
 
-parseRHTime :: String -> Maybe UTCTime
-parseRHTime = parseTime defaultTimeLocale "%FT%X%QZ"
 
-parseShortTime :: String -> Maybe Day
-parseShortTime = parseTime defaultTimeLocale "%F"
-
-queryRedmine :: RedmineMng -> S.ByteString -> IO L.ByteString
-queryRedmine mng req = do
-          request <- creerRqt mng req
-          let settings = mkManagerSettings (TLSSettingsSimple True False False) Nothing
-          response  <- withManagerSettings settings $ httpLbs request
-          return $ responseBody response
-
-creerRqt :: RedmineMng -> S.ByteString -> IO Request
-creerRqt (RedmineMng h) r                            = parseUrl $ S8.unpack (h <> r)
-creerRqt (RedmineMngWithProxy h u p) r               = fmap (addProxy u p) (creerRqt (RedmineMng h) r)
-creerRqt (RedmineMngWithAuth h l pass) r             = fmap (applyBasicAuth l pass) (creerRqt (RedmineMng h) r)
-creerRqt (RedmineMngWithAuthAndProxy h l pass u p) r = fmap (applyBasicAuth l pass) (creerRqt (RedmineMngWithProxy h u p) r)
-
-type ParamRest = Map.Map S.ByteString S.ByteString
-
--- Remplace par urlEncodedBody
-expandOptions :: ParamRest -> S.ByteString
-expandOptions = Map.foldrWithKey (\k a res -> res <> k <> "=" <> a <> "&") "?"
-
-bsAInt :: S.ByteString -> Int
-bsAInt = read . S8.unpack
-
-increaseQueryRange :: ParamRest -> ParamRest
-increaseQueryRange param =
-  let offset = bsAInt $ Map.findWithDefault "0" "offset" param
-      limit  = bsAInt $ Map.findWithDefault "100" "limit" param
-      nouvelOffset = offset + limit
-  in Map.insert "offset" (S8.pack $ show nouvelOffset) param
-
--- Réécrire avec les autres modes
-queryRedmineAvecOptions :: (FromJSON a, Monoid a, Collection a) =>
-                           RedmineMng -> S.ByteString -> ParamRest -> Manager -> IO( Maybe a)
-queryRedmineAvecOptions redmineMng req param mng = -- MaybeT IO $ withSocketsDo $
-  do
-    request   <- creerRqt redmineMng (req <> expandOptions param)
-    --traceM (S8.unpack $ (req <> (expandOptions param)))
-    let settings = mkManagerSettings (TLSSettingsSimple True False False) Nothing
-    response  <- withManagerSettings settings $ httpLbs request
-    parsedRes <- debugResult . eitherDecode . responseBody $ response
-    --putStrLn $ show parsedRes
-    case parsedRes of
-      Just a | 0 == longueur a -> return $ Just a
-             | otherwise       ->
-                do let hausse = increaseQueryRange param
-                   --traceM . show $ hausse
-                   reste <- queryRedmineAvecOptions redmineMng req hausse mng
-                   case reste of
-                      Just b -> return . Just $ mappend a b
-                      Nothing -> return $ Just a
-                   --return (reste >>= (\b -> Just $ mappend a b ))
-
-      Nothing -> return Nothing
-
--- |The function 'debugResult' is used to print the parsing error statement
--- and continue the processing.
-debugResult :: Either String a -> IO(Maybe a)
-debugResult res = case res of
-                    Left msg -> putStrLn msg >> return Nothing
-                    Right v  -> return (Just v)
-
-runQuery :: FromJSON a => RedmineMng -> S.ByteString -> IO( Maybe a)
-runQuery mng requete = do -- withSocketsDo $ do
-  toto <- queryRedmine mng requete
-  (debugResult . eitherDecode) toto
-
-initOpt = Map.fromList [("offset","0"), ("limit","100")]
 
 -- |The function 'getTimeEntries' fetches all the time entries.
 --  They can be filtered by spenton date using spent_on=%3E%3C2013-05-01|2013-05-31
 getTimeEntries :: RedmineMng -> ParamRest -> MaybeT IO [TimeEntry]
 getTimeEntries mng param = MaybeT $ do
    mngConn <- newManager tlsManagerSettings
-   res <- queryRedmineAvecOptions mng requete ( Map.union param initOpt) mngConn
+   res <- queryRedmineAvecOptions mng GET requete ( Map.union param initOpt) Nothing mngConn 
    return $ fmap time_entries res
    where requete = "/time_entries.json"
 
 getTimeEntry :: RedmineMng -> Integer -> MaybeT IO TimeEntry
 getTimeEntry mng elemId = 
-   fmap time_entry (MaybeT $ runQuery mng requete)
+   fmap time_entry (MaybeT $ runQuery mng GET requete Nothing)
    where requete = "/time_entries/" <> S8.pack (show elemId) <> ".json"
                 
 getTimeEntriesForIssue :: RedmineMng -> Integer-> MaybeT IO [TimeEntry]
 getTimeEntriesForIssue mng issueid = MaybeT $ do
    mngConn <- newManager tlsManagerSettings
-   res <- queryRedmineAvecOptions mng requete initOpt mngConn
+   res <- queryRedmineAvecOptions mng GET requete initOpt Nothing mngConn
    return $ fmap time_entries res
    where requete = "/time_entries/" <> S8.pack (show issueid) <> ".json"
 
 getIssues :: RedmineMng -> ParamRest -> MaybeT IO [Issue]
 getIssues mng param = MaybeT $ do
    mngConn <- liftIO $ newManager tlsManagerSettings
-   res <- queryRedmineAvecOptions mng requete ( Map.union param initOpt) mngConn
+   res <- queryRedmineAvecOptions mng GET requete ( Map.union param initOpt) Nothing mngConn
    return $ fmap issues res
    where requete = "/issues.json"
 
 getIssue :: RedmineMng -> Integer -> ParamRest -> MaybeT IO Issue
 getIssue mng elemId param =
-   fmap issue (MaybeT $ runQuery mng requete)
+   fmap issue (MaybeT $ runQuery mng GET requete Nothing)
    where requete = "/issues/" <> S8.pack (show elemId) <> ".json" <> expandOptions param
 
 getProjects :: RedmineMng -> MaybeT IO [Project]
 getProjects mng = MaybeT $ do
    mngConn <- newManager tlsManagerSettings
-   res <- queryRedmineAvecOptions mng requete initOpt mngConn
+   res <- queryRedmineAvecOptions mng GET requete initOpt Nothing mngConn 
    return $ fmap projects res
    where requete = "/projects.json"
 
 getProjectForId :: RedmineMng -> Integer -> MaybeT IO Project
 getProjectForId mng elemId =
-   MaybeT $ runQuery mng requete
+   MaybeT $ runQuery mng GET requete Nothing
    where requete = rmhost mng <> "/projects/" <> S8.pack (show elemId) <> ".json"
 
 getProject :: RedmineMng -> S.ByteString -> MaybeT IO Project
 getProject mng projId =
-   MaybeT $ runQuery mng requete
+   MaybeT $ runQuery mng GET requete Nothing
    where requete = "/projects/" <> projId <> ".json"
 
 --Get all the versions associated to a project
@@ -170,226 +86,15 @@ getVersions :: RedmineMng --The connection manager
             -> S.ByteString --The project
             -> MaybeT IO [Version]
 getVersions mng proj =
-   fmap versions (MaybeT $ runQuery mng requete)
+   fmap versions (MaybeT $ runQuery mng GET requete Nothing)
    where requete = "/projects/" <> proj <> "/versions.json"
 
 getVersion:: RedmineMng -> Integer -> ParamRest -> MaybeT IO Version
 getVersion mng elemId param =
-   fmap version (MaybeT $ runQuery mng requete)
+   fmap version (MaybeT $ runQuery mng GET requete Nothing)
    where requete = "/versions/" <> S8.pack (show elemId) <> ".json" <> expandOptions param
 
 getUser :: RedmineMng -> Integer -> MaybeT IO User
 getUser mng elemId =
-    fmap user (MaybeT $ runQuery mng requete)
+    fmap user (MaybeT $ runQuery mng GET requete Nothing)
     where requete = "/users/" <> S8.pack (show elemId) <> ".json"
-
-instance FromJSON ObjRef where
-  parseJSON (Object v) =
-    ObjRef <$> (v .: "id")
-           <*> (v .: "name")
-
-instance FromJSON ObjID where
-  parseJSON (Object v) =
-    ObjID <$> (v .: "id")
-
-instance FromJSON IssuesRsp where
-  parseJSON (Object v) = IssuesRsp <$> (v .: "issues")
-
-instance FromJSON IssueRsp where
-  parseJSON (Object v) = IssueRsp <$> (v .: "issue")
-
-instance FromJSON Issue where
-  parseJSON (Object v) =
-    Issue <$> (v .: "id")
-          <*> (v .: "project")
-          <*> (v .:? "parent")
-          <*> (v .: "tracker")
-          <*> (v .: "status")
-          <*> (v .: "priority")
-          <*> (v .: "author")
-          <*> (v .:? "assigned_to")
-          <*> (v .:? "category")
-          <*> (v .:? "fixed_version")
-          <*> (v .: "subject")
-          <*> (v .: "description")
-          <*> liftM (parseShortTime . fromMaybe "") (v .:? "start_date")
-          <*> liftM (parseShortTime . fromMaybe "") (v .:? "due_date")
-          <*> (v .: "done_ratio")
-          <*> (v .:? "estimated_hours")
-          <*> (v .:? "spent_hours")
-          <*> (v .:? "custom_fields")
-          <*> liftM parseRHTime (v .: "created_on")
-          <*> liftM parseRHTime (v .: "updated_on")
-          <*> (v .:? "journals")
-          <*> (v .:? "attachements")
-          <*> (v .:? "changesets")
-          <*> (v .:? "watchers")
-          <*> (v .:? "relations")
-          <*> (v .:? "children")
-
-
-instance FromJSON Child where
-  parseJSON (Object v) =
-    Child <$> (v .: "id")
-          <*> (v .: "tracker")
-          <*> (v .: "subject")
-
-instance FromJSON Attachement where
-  parseJSON (Object v) =
-    Attachement <$> (v .: "id")
-                <*> (v .: "filename")
-                <*> (v .: "filesize")
-                <*> (v .: "content_type")
-                <*> (v .: "description")
-                <*> (v .: "content_url")
-                <*> (v .: "author_name")
-                <*> liftM (fromJust.parseRHTime) (v .: "created_on")
-
-instance FromJSON ChangeSet where
-  parseJSON (Object v) =
-    ChangeSet <$> (v .: "revision")
-              <*> (v .: "user")
-              <*> (v .: "comments")
-              <*> liftM (fromJust.parseRHTime) (v .: "committed_on")
-
-instance FromJSON Watcher where
-  parseJSON (Object v) =
-    Watcher <$> (v .: "id")
-            <*> (v .: "name")
-
-instance FromJSON CustomField where
-  parseJSON (Object v) =
-    CustomField <$> (v .: "id") <*> (v .: "name") <*> (v .: "value")
-
-instance FromJSON Journal where
-  parseJSON (Object v) =
-    Journal <$> (v .: "id")
-            <*> (v .: "user")
-            <*> (v .:? "notes" .!= "")
-            <*> liftM parseRHTime (v .: "created_on")
-            <*> (v .: "details")
-
-instance FromJSON Detail where
-  parseJSON (Object v) =
-    Detail  <$> (v .: "property")
-            <*> (v .: "name")
-            <*> (v .:? "old_value")
-            <*> (v .: "new_value")
-
-instance FromJSON ProjectsRsp where
-  parseJSON (Object v) = ProjectsRsp <$> (v .: "projects")
-
-instance FromJSON Project where
-  parseJSON (Object v) =
-    Project <$> (v .: "id")
-            <*> (v .: "name")
-            <*> (v .: "identifier")
-            <*> (v .: "description")
-            <*> (v .:? "custom_fields")
-            <*> liftM parseRHTime (v .: "created_on")
-            <*> liftM parseRHTime (v .: "updated_on")
-
-instance FromJSON TimeEntriesRsp where
-  parseJSON (Object v) = TimeEntriesRsp <$> (v .: "time_entries")
-
-instance FromJSON TimeEntryRsp where
-  parseJSON (Object v) = TimeEntryRsp <$> (v .: "time_entry")
-
-instance FromJSON TimeEntry where
-  parseJSON (Object v) =
-    TimeEntry <$> (v .: "id")
-              <*> (v .: "project")
-              <*> (v .: "issue")
-              <*> (v .: "user")
-              <*> (v .:? "activity")
-              <*> (v .:? "hours")
-              <*> (v .: "comments")
-              <*> liftM parseRHTime (v .: "created_on")
-              <*> liftM parseRHTime (v .: "updated_on")
-              <*> liftM (parseShortTime . fromMaybe "") (v .:? "spent_on")
-
-instance FromJSON VersionsRsp where
-  parseJSON (Object v) = VersionsRsp <$> (v .: "versions")
-
-instance FromJSON VersionRsp where
-  parseJSON (Object v) = VersionRsp <$> (v .: "version")
-
-instance FromJSON Day where
-    parseJSON = withText "Day" $ \t ->
-        case parseTime defaultTimeLocale "%F" (T.unpack t) of
-          Just d -> pure d
-          _      -> fail "could not parse ISO-8601 date"
-
-instance FromJSON Version where
-  parseJSON (Object v) =
-    Version <$> (v .: "id")
-            <*> (v .: "name")
-            <*> (v .: "project")
-            <*> (v .: "description")
-            <*> (v .: "status")
-            <*> (v .: "sharing")
-            --FIXME avoid parsing an empty string
-            <*> liftM (parseShortTime . fromMaybe "") (v .:? "due_date")
-            <*> liftM parseRHTime (v .: "created_on")
-            <*> liftM parseRHTime (v .: "updated_on")
-
-instance FromJSON Relations where
-  parseJSON (Object v) = Relations <$> (v .: "relations")
-
-instance FromJSON Relation where
-  parseJSON (Object v) =
-    Relation <$> (v .: "id")
-             <*> (v .: "issue_id")
-             <*> (v .: "issue_to_id")
-             <*> (v .: "relation_type")
-             <*> (v .:? "delay")
-
-instance FromJSON Roles where
-  parseJSON (Object v) = Roles <$> (v .: "roles")
-
-instance FromJSON Role where
-  parseJSON (Object v) =
-    Role <$> (v .: "id") <*> (v .: "name")
-
-instance FromJSON Memberships where
-  parseJSON (Object v) = Memberships <$> (v .: "memberships")
-
-instance FromJSON Membership where
-  parseJSON (Object v) =
-    Membership <$> (v .: "id")
-               <*> (v .: "project")
-               <*> (v .: "user")
-               <*> (v .: "roles")
-
-instance FromJSON UsersRsp where
-  parseJSON (Object v) = UsersRsp <$> (v .: "users")
-
-instance FromJSON UserRsp where
-  parseJSON (Object v) = UserRsp <$> (v .: "user")
-
-instance FromJSON User where
-  parseJSON (Object v) =
-    User <$> (v .: "lastname")
-         <*> liftM parseRHTime (v .: "created_on")
-         <*> (v .: "mail")
-         <*> liftM parseRHTime (v .: "last_login_on")
-         <*> (v .: "firstname")
-         <*> (v .: "id")
-
-instance FromJSON Trackers where
-  parseJSON (Object v) = Trackers <$> (v .: "trackers")
-
-instance FromJSON Tracker where
-  parseJSON (Object v) =
-    Tracker <$> (v .: "id") <*> (v .: "name")
-
-instance FromJSON IssueStatuses where
-  parseJSON (Object v) = IssueStatuses <$> (v .: "issue_statuses")
-
-instance FromJSON IssueStatus where
-  parseJSON (Object v) =
-    IssueStatus <$> (v .: "id")
-                <*> (v .: "name")
-                <*> (v .: "is_default")
-                <*> (v .: "is_closed")
-

--- a/src/Redmine/JSON.hs
+++ b/src/Redmine/JSON.hs
@@ -1,0 +1,349 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Redmine.JSON where
+
+import Data.Aeson
+import Data.Maybe
+import Data.Time.Format (parseTime)
+import Redmine.Types
+import Redmine.Utils
+import Control.Applicative ((<$>), (<*>), pure)
+import Control.Monad (liftM)
+import Data.Time.Calendar (Day, showGregorian)
+import System.Locale        (defaultTimeLocale)
+
+import qualified Data.Text  as T (pack, unpack)
+
+instance FromJSON ObjRef where
+  parseJSON (Object v) =
+    ObjRef <$> (v .: "id")
+           <*> (v .: "name")
+
+instance FromJSON ObjID where
+  parseJSON (Object v) =
+    ObjID <$> (v .: "id")
+
+instance FromJSON IssuesRsp where
+  parseJSON (Object v) = IssuesRsp <$> (v .: "issues")
+
+instance FromJSON IssueRsp where
+  parseJSON (Object v) = IssueRsp <$> (v .: "issue")
+
+instance FromJSON Issue where
+  parseJSON (Object v) =
+    Issue <$> (v .: "id")
+          <*> (v .: "project")
+          <*> (v .:? "parent")
+          <*> (v .: "tracker")
+          <*> (v .: "status")
+          <*> (v .: "priority")
+          <*> (v .: "author")
+          <*> (v .:? "assigned_to")
+          <*> (v .:? "category")
+          <*> (v .:? "fixed_version")
+          <*> (v .: "subject")
+          <*> liftM (fromMaybe "") (v .:? "description")
+          <*> liftM (parseShortTime . fromMaybe "") (v .:? "start_date")
+          <*> liftM (parseShortTime . fromMaybe "") (v .:? "due_date")
+          <*> (v .: "done_ratio")
+          <*> (v .:? "estimated_hours")
+          <*> (v .:? "spent_hours")
+          <*> (v .:? "custom_fields")
+          <*> liftM parseRHTime (v .: "created_on")
+          <*> liftM parseRHTime (v .: "updated_on")
+          <*> (v .:? "journals")
+          <*> (v .:? "attachements")
+          <*> (v .:? "changesets")
+          <*> (v .:? "watchers")
+          <*> (v .:? "relations")
+          <*> (v .:? "children")
+
+
+instance FromJSON Child where
+  parseJSON (Object v) =
+    Child <$> (v .: "id")
+          <*> (v .: "tracker")
+          <*> (v .: "subject")
+
+instance FromJSON Attachement where
+  parseJSON (Object v) =
+    Attachement <$> (v .: "id")
+                <*> (v .: "filename")
+                <*> (v .: "filesize")
+                <*> (v .: "content_type")
+                <*> (v .: "description")
+                <*> (v .: "content_url")
+                <*> (v .: "author_name")
+                <*> liftM (fromJust.parseRHTime) (v .: "created_on")
+
+instance FromJSON ChangeSet where
+  parseJSON (Object v) =
+    ChangeSet <$> (v .: "revision")
+              <*> (v .: "user")
+              <*> (v .: "comments")
+              <*> liftM (fromJust.parseRHTime) (v .: "committed_on")
+
+instance FromJSON Watcher where
+  parseJSON (Object v) =
+    Watcher <$> (v .: "id")
+            <*> (v .: "name")
+
+instance FromJSON CustomField where
+  parseJSON (Object v) =
+    CustomField <$> (v .: "id") <*> (v .: "name") <*> (v .: "value")
+
+instance FromJSON Journal where
+  parseJSON (Object v) = 
+    Journal <$> (v .: "id")
+            <*> (v .: "user")
+            <*> (v .:? "notes" .!= "")
+            <*> liftM parseRHTime (v .: "created_on")
+            <*> (v .: "details")
+
+instance FromJSON Detail where
+  parseJSON (Object v) =
+    Detail  <$> (v .: "property")
+            <*> (v .: "name")
+            <*> (v .:? "old_value")
+            <*> (v .: "new_value")
+
+instance FromJSON ProjectsRsp where
+  parseJSON (Object v) = ProjectsRsp <$> (v .: "projects")
+
+instance FromJSON Project where
+  parseJSON (Object v) =
+    Project <$> (v .: "id")
+            <*> (v .: "name")
+            <*> (v .: "identifier")
+            <*> (v .: "description")
+            <*> (v .:? "custom_fields")
+            <*> liftM parseRHTime (v .: "created_on")
+            <*> liftM parseRHTime (v .: "updated_on")
+
+instance FromJSON TimeEntriesRsp where
+  parseJSON (Object v) = TimeEntriesRsp <$> (v .: "time_entries")
+
+instance FromJSON TimeEntryRsp where
+  parseJSON (Object v) = TimeEntryRsp <$> (v .: "time_entry")
+
+instance FromJSON TimeEntry where
+  parseJSON (Object v) =
+    TimeEntry <$> (v .: "id")
+              <*> (v .: "project")
+              <*> (v .: "issue")
+              <*> (v .: "user")
+              <*> (v .:? "activity")
+              <*> (v .:? "hours")
+              <*> (v .: "comments")
+              <*> liftM parseRHTime (v .: "created_on")
+              <*> liftM parseRHTime (v .: "updated_on")
+              <*> liftM (parseShortTime . fromMaybe "") (v .:? "spent_on")
+
+instance FromJSON VersionsRsp where
+  parseJSON (Object v) = VersionsRsp <$> (v .: "versions")
+
+instance FromJSON VersionRsp where
+  parseJSON (Object v) = VersionRsp <$> (v .: "version")
+
+instance FromJSON Day where
+    parseJSON = withText "Day" $ \t ->
+        case parseTime defaultTimeLocale "%F" (T.unpack t) of
+          Just d -> pure d
+          _      -> fail "could not parse ISO-8601 date"
+
+instance FromJSON Version where
+  parseJSON (Object v) =
+    Version <$> (v .: "id")
+            <*> (v .: "name")
+            <*> (v .: "project")
+            <*> (v .: "description")
+            <*> (v .: "status")
+            <*> (v .: "sharing")
+            --FIXME avoid parsing an empty string
+            <*> liftM (parseShortTime . fromMaybe "") (v .:? "due_date")
+            <*> liftM parseRHTime (v .: "created_on")
+            <*> liftM parseRHTime (v .: "updated_on")
+
+instance FromJSON Relations where
+  parseJSON (Object v) = Relations <$> (v .: "relations")
+
+instance FromJSON Relation where
+  parseJSON (Object v) =
+    Relation <$> (v .: "id")
+             <*> (v .: "issue_id")
+             <*> (v .: "issue_to_id")
+             <*> (v .: "relation_type")
+             <*> (v .:? "delay")
+
+instance FromJSON Roles where
+  parseJSON (Object v) = Roles <$> (v .: "roles")
+
+instance FromJSON Role where
+  parseJSON (Object v) =
+    Role <$> (v .: "id") <*> (v .: "name")
+
+instance FromJSON Memberships where
+  parseJSON (Object v) = Memberships <$> (v .: "memberships")
+
+instance FromJSON Membership where
+  parseJSON (Object v) =
+    Membership <$> (v .: "id")
+               <*> (v .: "project")
+               <*> (v .: "user")
+               <*> (v .: "roles")
+
+instance FromJSON UsersRsp where
+  parseJSON (Object v) = UsersRsp <$> (v .: "users")
+
+instance FromJSON UserRsp where
+  parseJSON (Object v) = UserRsp <$> (v .: "user")
+
+instance FromJSON User where
+  parseJSON (Object v) =
+    User <$> (v .: "lastname")
+         <*> liftM parseRHTime (v .: "created_on")
+         <*> (v .: "mail")
+         <*> liftM parseRHTime (v .: "last_login_on")
+         <*> (v .: "firstname")
+         <*> (v .: "id")
+
+instance FromJSON Trackers where
+  parseJSON (Object v) = Trackers <$> (v .: "trackers")
+
+instance FromJSON Tracker where
+  parseJSON (Object v) =
+    Tracker <$> (v .: "id") <*> (v .: "name")
+
+instance FromJSON IssueStatuses where
+  parseJSON (Object v) = IssueStatuses <$> (v .: "issue_statuses")
+
+instance FromJSON IssueStatus where
+  parseJSON (Object v) =
+    IssueStatus <$> (v .: "id")
+                <*> (v .: "name")
+                <*> (v .: "is_default")
+                <*> (v .: "is_closed")
+
+instance ToJSON Day where
+  toJSON = String . T.pack . showGregorian
+
+instance ToJSON ObjRef where
+  toJSON (ObjRef id name) = object [ "id" .= id, "name" .= name]
+
+instance ToJSON ObjID where
+  toJSON (ObjID id) = object ["id" .= id]
+
+instance ToJSON Issue where
+  toJSON (Issue _id'
+          project
+          _parent
+          _tracker
+          _status
+          _priority
+          _author
+          _assigned_to
+          _category
+          _fixed_version
+          subject
+          description
+          _start_date
+          _due_date
+          _done_ratio
+          _estimated_hours
+          _spent_hours
+          _custom_fields
+          _created_on
+          _updated_on
+          _journals
+          _attachements
+          _changesets
+          _watchers
+          _relations
+          _children
+         ) =    object  [ "issue" .= 
+    object [ -- "id" .= id',
+             "project_id" .= id_ObjRef project
+--           , "tracker" .= tracker
+--           , "status" .= status
+--           , "priority" .= priority
+--           , "author"   .= author
+--           , "assigned_to" .= assigned_to
+--           , "category" .= category
+--           , "fixed_version" .= fixed_version
+           , "subject" .= subject
+           , "description" .= description
+--           , "start_date" .= start_date
+--           , "due_date" .= due_date
+--           , "done_ratio" .= done_ratio
+--           , "estimated_hours" .= estimated_hours
+--           , "spent_hours" .= spent_hours
+--           , "custom_fields" .= custom_fields
+--           , "created_on" .= created_on
+--           , "updated_on" .= updated_on
+--           , "journals" .= journals
+--           , "attachements" .= attachements
+--           , "changesets" .= changesets
+--           , "watchers" .= watchers
+--           , "relations" .= relations
+--           , "children" .= children
+           ]]
+  
+instance ToJSON Child where
+  toJSON (Child id' tracker subject) =
+    object [ "id" .= id'
+           , "tracker" .= tracker
+           , "subject" .= subject]
+
+instance ToJSON Attachement where
+  toJSON (Attachement id' filename filesize content_type description content_url author_name created_on) =
+    object [ "id" .= id'
+           , "filename" .= filename
+           , "filesize" .= filesize
+           , "content_type" .= content_type
+           , "description" .= description
+           , "content_url" .= content_url
+           , "author_name" .= author_name
+           , "created_on" .= created_on]
+
+instance ToJSON ChangeSet where
+  toJSON (ChangeSet revision user comments committed_on) =
+    object [ "revision" .= revision
+           , "user" .= user
+           , "comments" .= comments
+           , "commited_on" .= committed_on]
+
+             
+instance ToJSON CustomField where
+  toJSON (CustomField id' name value) =
+    object ["id" .= id'
+           , "name" .= name
+           , "value" .= value]
+
+instance ToJSON Journal where
+  toJSON (Journal id' user notes created_on details) =
+    object ["id" .= id'
+           , "user" .= user
+           , "notes" .= notes
+           , "created_on" .= created_on
+           , "details" .= details]
+
+instance ToJSON Detail where
+  toJSON (Detail property name old_value new_value) =
+    object [ "property" .= property
+           , "name" .= name
+           , "old_value" .= old_value
+           , "new_value" .= new_value]
+
+instance ToJSON Watcher where
+  toJSON (Watcher id' name) =
+    object [ "id" .= id'
+           , "name" .= name]
+  
+instance ToJSON Relation where
+  toJSON (Relation id' issue_id issue_to_id relation_type delay) =
+    object [ "id" .= id'
+           , "issue_id" .= issue_id
+           , "issue_to_id" .= issue_to_id
+           , "relation_type" .= relation_type
+           , "delay" .= delay]
+

--- a/src/Redmine/Post.hs
+++ b/src/Redmine/Post.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Redmine.Post (postIssue) where
+
+import Data.Aeson
+import Data.Monoid
+import qualified Data.Map as Map
+import Redmine.JSON
+import Redmine.Types
+import Redmine.Manager
+import Redmine.Rest
+import qualified Data.ByteString as S
+import qualified Data.ByteString.Char8 as S8
+import qualified Data.ByteString.Lazy.Char8 as L8
+import Network.HTTP.Conduit
+import Network.HTTP.Base (RequestMethod(..))
+import Network.HTTP.Client.TLS
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Maybe
+import Debug.Trace
+
+
+postIssue :: RedmineMng -> Issue -> MaybeT IO Issue
+postIssue mng iss =
+  fmap issue (MaybeT $ runQuery mng POST requete (toJsonBody iss))
+  where requete = "issues.json" 
+
+
+
+       

--- a/src/Redmine/Put.hs
+++ b/src/Redmine/Put.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Redmine.Put where

--- a/src/Redmine/Rest.hs
+++ b/src/Redmine/Rest.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Redmine.Rest(expandOptions
+                   , increaseQueryRange
+                   , initOpt
+                   , toJsonBody
+                   , queryRedmineAvecOptions
+                   , runQuery
+
+                   , ParamRest
+                   ) where
+
+import Data.Aeson
+import Data.Monoid
+import qualified Data.Map as Map
+import Redmine.Types
+import Redmine.Manager
+import qualified Data.ByteString as S
+import qualified Data.ByteString.Char8 as S8
+import qualified Data.ByteString.Lazy as L
+import qualified Data.ByteString.Lazy.Char8 as L8
+import Network.Connection (TLSSettings (..))
+import Network.HTTP.Conduit
+import Network.HTTP.Base (RequestMethod(..))
+import Network.HTTP.Types.Header (Header, hContentType)
+import qualified Data.Text as T
+
+import Debug.Trace
+
+queryRedmine :: RedmineMng -> RequestMethod -> S.ByteString -> (Maybe S.ByteString) -> IO L.ByteString
+queryRedmine mng m req b = do
+          request <- creerRqt mng m req b
+          let settings = mkManagerSettings (TLSSettingsSimple True False False) Nothing
+          response  <- withManagerSettings settings $ httpLbs request
+          return $ responseBody response
+
+creerRqt :: RedmineMng -> RequestMethod -> S.ByteString -> Maybe S.ByteString -> IO Request
+creerRqt (RedmineMng h) m r body                       =  fmap (f body) $ parseUrl $ S8.unpack (h <> r)
+  where
+    ct = (hContentType, "application/json") :: Header
+    f (Just b) req = trace (S8.unpack b) req'
+      where req' = req{method = S8.pack . show $ m, requestHeaders = ct : requestHeaders req, requestBody = RequestBodyBS b}
+    f Nothing  req = req{method = S8.pack . show $ m, requestHeaders = ct : requestHeaders req}
+
+creerRqt (RedmineMngWithProxy h u p) m r b               = fmap (addProxy u p) (creerRqt (RedmineMng h) m r b)
+creerRqt (RedmineMngWithAuth h l pass) m r b             = fmap (applyBasicAuth l pass) (creerRqt (RedmineMng h) m r b)
+creerRqt (RedmineMngWithAuthAndProxy h l pass u p) m r b = fmap (applyBasicAuth l pass) (creerRqt (RedmineMngWithProxy h u p) m r b)
+
+type ParamRest = Map.Map S.ByteString S.ByteString
+
+-- Remplace par urlEncodedBody
+expandOptions :: ParamRest -> S.ByteString
+expandOptions = Map.foldrWithKey (\k a res -> res <> k <> "=" <> a <> "&") "?"
+
+bsAInt :: S.ByteString -> Int
+bsAInt = read . S8.unpack
+
+increaseQueryRange :: ParamRest -> ParamRest
+increaseQueryRange param =
+  let offset = bsAInt $ Map.findWithDefault "0" "offset" param
+      limit  = bsAInt $ Map.findWithDefault "100" "limit" param
+      nouvelOffset = offset + limit
+  in Map.insert "offset" (S8.pack $ show nouvelOffset) param
+
+-- Réécrire avec les autres modes
+queryRedmineAvecOptions :: (FromJSON a, Monoid a, Collection a) =>
+                           RedmineMng -> RequestMethod -> S.ByteString -> ParamRest -> Maybe S.ByteString -> Manager -> IO( Maybe a)
+queryRedmineAvecOptions redmineMng m req param body mng = -- MaybeT IO $ withSocketsDo $
+  do
+    request   <- creerRqt redmineMng m (req <> expandOptions param) body
+    --traceM (S8.unpack $ (req <> (expandOptions param)))
+    let settings = mkManagerSettings (TLSSettingsSimple True False False) Nothing
+    response  <- withManagerSettings settings $ httpLbs request
+    parsedRes <- debugResult . eitherDecode . responseBody $ response
+    --putStrLn $ show parsedRes
+    case parsedRes of
+      Just a | 0 == longueur a -> return $ Just a
+             | otherwise       ->
+                do let hausse = increaseQueryRange param
+                   --traceM . show $ hausse
+                   reste <- queryRedmineAvecOptions redmineMng m req hausse body mng
+                   case reste of
+                      Just b -> return . Just $ mappend a b
+                      Nothing -> return $ Just a
+                   --return (reste >>= (\b -> Just $ mappend a b ))
+
+      Nothing -> return Nothing
+
+-- |The function 'debugResult' is used to print the parsing error statement
+-- and continue the processing.
+debugResult :: Either String a -> IO(Maybe a)
+debugResult res = case res of
+                    Left msg -> putStrLn msg >> return Nothing
+                    Right v  -> return (Just v)
+
+--contentType = mkHeader HdrContentType "application/json"
+
+runQuery :: FromJSON a => RedmineMng -> RequestMethod -> S.ByteString -> Maybe S.ByteString -> IO( Maybe a)
+runQuery mng m requete body = do -- withSocketsDo $ do
+  toto <- queryRedmine mng m requete body
+  (debugResult . eitherDecode) toto
+
+toJsonBody :: ToJSON a => a -> Maybe S8.ByteString
+toJsonBody = Just . L8.toStrict . encode . toJSON
+
+initOpt = Map.fromList [("offset","0"), ("limit","100")] :: Map.Map S8.ByteString S8.ByteString

--- a/src/Redmine/Utils.hs
+++ b/src/Redmine/Utils.hs
@@ -1,0 +1,17 @@
+module Redmine.Utils (parseRHTime, parseShortTime) where
+import Data.Time.Format     (parseTime)
+import Data.Time.Clock      (UTCTime)
+import Data.Time.Calendar (Day)
+import System.Locale        (defaultTimeLocale)
+
+
+parseRHTime :: String -> Maybe UTCTime
+parseRHTime = parseTime defaultTimeLocale "%FT%X%QZ"
+
+parseShortTime :: String -> Maybe Day
+parseShortTime = parseTime defaultTimeLocale "%F"
+{-
+a = parseRHTime "2015-10-11T02:00:00Z"
+b = parseRHTime "2015-10-11T03:00:00Z"
+x = parseShortTime "2015-10-11"
+-}


### PR DESCRIPTION
Hi. lookunder.
## I'm trying to extend your RedmineHs library to support non GET method for post issues from my application. Before I create many code, I'd like you to review my code and update hackage code, if possible. I added some new APIs and moved some code, but I also tried to keep external API same as before. Thanks in advance.

Sample code for post an issue is implemented in Post.hs.
- JSON related code originaly in Get.hs are moved to JSON.hs.
- ToJSON code are added in JSON.hs
- Code to request for Redmine server are moved to Rest.hs from Get.hs to share between Get.hs and Post.hs
  - runQuery or other code are extended to support POST or other method and to accept data to be sent to Redmine Server.
- code usable for user are moved to Utils.hs
